### PR TITLE
Feature/fix ie height goofiness

### DIFF
--- a/lib/justified-columns.js
+++ b/lib/justified-columns.js
@@ -105,15 +105,16 @@ JustifiedColumns = (function(window) {
                             stretchable.style.objectPosition = 'center';
                         } else {
                             //it's an IMG and we're in older IE, ugh
-                            //create overflow wrapper, set wrapper max/min-height, position within wrapper
                             if (stretchable.parentNode.className !== WRAPPER_CLASS) {
+                                //create overflow wrapper
                                 var wrapper = document.createElement('DIV');
                                 wrapper.className = WRAPPER_CLASS;
                                 wrapper.style.overflow = 'hidden';
                                 wrapper.style[heightProperty] = newHeight + 'px';
                                 stretchable.parentNode.replaceChild(wrapper, stretchable);
+                                wrapper.appendChild(stretchable);
                             }
-                            wrapper.appendChild(stretchable);
+                            //set wrapper max/min-height, position within wrapper
                             if (self.shrink) {
                                 var sOffset = 0.5 * (newHeight - gridItem.stretchableHeight);
                                 stretchable.style.marginTop = sOffset + 'px';
@@ -133,6 +134,12 @@ JustifiedColumns = (function(window) {
                 column.totalImagesHeight += stretchedImagesDelta;
             }
         });
+
+        //Fix the stupid IE10/11 interactions between column-count grid and height/max-height children
+        if (NEEDS_WRAPPER && abs(this.grid.offsetHeight - referenceColumn) >= 2) {
+            this.grid.style.height = referenceColumn + 'px';
+        }
+
     };
 
     Justifier.prototype.reset = function() {
@@ -152,6 +159,7 @@ JustifiedColumns = (function(window) {
             [].slice.call(this.grid.getElementsByClassName(WRAPPER_CLASS)).forEach(function(wrapper) {
                 wrapper.parentNode.replaceChild(wrapper.firstChild, wrapper);
             });
+            this.grid.style.height = '';
         }
     };
 

--- a/lib/justified-columns.js
+++ b/lib/justified-columns.js
@@ -136,7 +136,7 @@ JustifiedColumns = (function(window) {
         });
 
         //Fix the stupid IE10/11 interactions between column-count grid and height/max-height children
-        if (NEEDS_WRAPPER && abs(this.grid.offsetHeight - referenceColumn) >= 2) {
+        if (NEEDS_WRAPPER && Math.abs(this.grid.offsetHeight - referenceColumn) >= 2) {
             this.grid.style.height = referenceColumn + 'px';
         }
 

--- a/lib/justified-columns.js
+++ b/lib/justified-columns.js
@@ -57,7 +57,11 @@ JustifiedColumns = (function(window) {
             columns = [],
             currentColumn = -1,
             referenceColumn = this.shrink ? Number.POSITIVE_INFINITY : 0,
-            currentOffset;
+            currentOffset, gridHeight;
+
+        if (NEEDS_WRAPPER) {
+            gridHeight = this.grid.offsetHeight;
+        }
 
         //sort the grid into columns based on offsetLeft; cache heights
         [].slice.call(this.grid.children).forEach(function(gridItem) {
@@ -136,8 +140,8 @@ JustifiedColumns = (function(window) {
         });
 
         //Fix the stupid IE10/11 interactions between column-count grid and height/max-height children
-        if (NEEDS_WRAPPER && Math.abs(this.grid.offsetHeight - referenceColumn) >= 2) {
-            this.grid.style.height = referenceColumn + 'px';
+        if (gridHeight && Math.abs(this.grid.offsetHeight - gridHeight) >= 2) {
+            this.grid.style.height = gridHeight + 'px';
         }
 
     };


### PR DESCRIPTION
IE10/11 have a bug wherein adding values of min-height/height to child elements in a "grid" that uses the "column-count" display property will add extra height to the grid itself (in a non-linear manner).  The manifests as "extra padding" on the bottom of the rid, and can be hundreds of extra pixels.  While this is not strictly a problem of the justified-columns library, given the expectation of using height on images (etc) and column count, the library should automatically clean-up this errant height.